### PR TITLE
fix: make sure selection highlights are cleared on window closed.

### DIFF
--- a/lua/ssr.lua
+++ b/lua/ssr.lua
@@ -153,9 +153,9 @@ function Ui:open()
       self:search()
     end,
   })
-  api.nvim_create_autocmd({ "BufDelete", "BufWipeout" }, {
+  api.nvim_create_autocmd({ "WinClosed" }, {
     buffer = self.ui_buf,
-    callback = function(a)
+    callback = function()
       api.nvim_buf_clear_namespace(self.origin_buf, self.ns, 0, -1)
       api.nvim_buf_clear_namespace(self.origin_buf, self.cur_match_ns, 0, -1)
       keymap.del("n", "n", { buffer = self.origin_buf })


### PR DESCRIPTION
There is a bug where if you leave the ssr window the highlights are still left behind the extmarks should be cleared when the window closes, I've been using this fix for months now with no known issues.