### PR TITLE
Introduce 'adjust_window' option to enable or disable automatic window adjustment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ use {
       min_height = 5,
       max_width = 120,
       max_height = 25,
+      adjust_window = true,
       keymaps = {
         close = "q",
         next_match = "n",

--- a/lua/ssr.lua
+++ b/lua/ssr.lua
@@ -17,6 +17,7 @@ local config = {
   min_height = 5,
   max_width = 120,
   max_height = 25,
+  adjust_window = true,
   keymaps = {
     close = "q",
     next_match = "n",
@@ -137,13 +138,15 @@ function Ui.new()
     group = self.augroup,
     buffer = self.ui_buf,
     callback = function()
-      local lines = api.nvim_buf_get_lines(self.ui_buf, 0, -1, true)
-      local width, height = u.get_win_size(lines, config)
-      if api.nvim_win_get_width(ui_win) ~= width then
-        api.nvim_win_set_width(ui_win, width)
-      end
-      if api.nvim_win_get_height(ui_win) ~= height then
-        api.nvim_win_set_height(ui_win, height)
+      if config.adjust_window then
+        local lines = api.nvim_buf_get_lines(self.ui_buf, 0, -1, true)
+        local width, height = u.get_win_size(lines, config)
+        if api.nvim_win_get_width(ui_win) ~= width then
+          api.nvim_win_set_width(ui_win, width)
+        end
+        if api.nvim_win_get_height(ui_win) ~= height then
+          api.nvim_win_set_height(ui_win, height)
+        end
       end
       self:search()
     end,


### PR DESCRIPTION
**Motivation:**

This pull request introduces an 'adjust_window' option for the ssr.nvim plugin. The motivation behind this addition is to address an issue when integrating ssr.nvim with other plugins like edgy. When the ssr.nvim window is set as a side layout within edgy, the automatic adjustment of the window size can lead to unexpected behavior, causing the cursor to jump to random locations during text insertion. By introducing the 'adjust_window' option, users can now control whether ssr.nvim should automatically adjust its window size or maintain a fixed size, providing a solution for this issue and offering greater compatibility with window management plugins like edgy.
